### PR TITLE
Fix deprecations

### DIFF
--- a/data-raw/catholic-dioceses.R
+++ b/data-raw/catholic-dioceses.R
@@ -15,5 +15,5 @@ catholic_dioceses <-
   gather(event, date, -diocese, -rite, -lat, -long) %>%
   filter(date != "") %>%
   mutate(date = mdy(date)) %>%
-  tbl_df()
-devtools::use_data(catholic_dioceses, overwrite = TRUE)
+  as_tibble()
+usethis::use_data(catholic_dioceses, overwrite = TRUE)

--- a/data-raw/cesta-cities.R
+++ b/data-raw/cesta-cities.R
@@ -38,4 +38,4 @@ cities <- cities %>%
 
 us_cities_pop <- cities
 
-devtools::use_data(us_cities_pop, overwrite = TRUE)
+usethis::use_data(us_cities_pop, overwrite = TRUE)

--- a/data-raw/dijon-prices-prep.R
+++ b/data-raw/dijon-prices-prep.R
@@ -1,7 +1,7 @@
 library(readr)
 library(tidyr)
 library(dplyr)
-library(devtools)
+library(tibble)
 library(stringr)
 
 dijon_prices_wide <- read_csv("data-raw/dijon-prices-wide.csv")
@@ -9,7 +9,7 @@ dijon_citations <- read_csv("data-raw/dijon-citations.csv") %>%
   select(-1) %>%
   t() %>%
   as.data.frame() %>%
-  add_rownames() %>%
+  rownames_to_column() %>%
   select(year = 1, citation = 2, citation_date = 3) %>%
   mutate(year = as.numeric(year))
 
@@ -17,4 +17,4 @@ dijon_prices <- dijon_prices_wide %>%
   gather(year, price, -commodity, -measure, na.rm = TRUE, convert = TRUE) %>%
   left_join(dijon_citations)
 
-use_data(dijon_prices_wide, dijon_prices, overwrite = TRUE)
+usethis::use_data(dijon_prices_wide, dijon_prices, overwrite = TRUE)

--- a/data-raw/early-colleges.R
+++ b/data-raw/early-colleges.R
@@ -2,5 +2,5 @@ library(dplyr)
 early_colleges <- read.csv("data-raw/early-colleges.csv", stringsAsFactors = FALSE,
                            na.strings = "")
 early_colleges <- early_colleges %>%
-  tbl_df()
-devtools::use_data(early_colleges, overwrite = TRUE)
+  as_tibble()
+usethis::use_data(early_colleges, overwrite = TRUE)

--- a/data-raw/federal-judges.R
+++ b/data-raw/federal-judges.R
@@ -9,7 +9,7 @@ export_url <- "http://www.fjc.gov/history/export/jb.txt"
 download.file(export_url, destfile = "data-raw/judges.csv")
 
 judges <- read.csv("data-raw/judges.csv", stringsAsFactors = FALSE) %>%
-  tbl_df()
+  as_tibble()
 
 judges_people <- judges %>%
   select(judge_id = Judge.Identification.Number,
@@ -75,4 +75,4 @@ judges_appointments[judges_appointments == " "] <- NA
 judges_appointments <- judges_appointments %>%
   filter(!is.na(court_name))
 
-use_data(judges_people, judges_appointments, overwrite = TRUE)
+usethis::use_data(judges_people, judges_appointments, overwrite = TRUE)

--- a/data-raw/methodists.R
+++ b/data-raw/methodists.R
@@ -23,4 +23,4 @@ methodists <- read_csv("data-raw/methodists.csv") %>%
   select(year, conference, district, meeting, state, members_total,
          starts_with("members_"), url)
 
-devtools::use_data(methodists, overwrite = TRUE)
+usethis::use_data(methodists, overwrite = TRUE)

--- a/data-raw/naval-promotions.R
+++ b/data-raw/naval-promotions.R
@@ -5,7 +5,7 @@ naval_promotions <- read.csv("data-raw/naval-promotions.csv",
 # Assign a unique ID to each person:
 naval_promotions$id <- 1:nrow(naval_promotions)
 naval_promotions <- naval_promotions %>%
-  tbl_df() %>%
+  as_tibble() %>%
   select(id,
          name,
          generation = Generation,
@@ -16,4 +16,4 @@ naval_promotions <- naval_promotions %>%
          left_service = date.leftservice) %>%
   gather(rank, date, -id, -name, -generation, na.rm = TRUE) %>%
   filter(date != "")
-devtools::use_data(naval_promotions, overwrite = TRUE)
+usethis::use_data(naval_promotions, overwrite = TRUE)

--- a/data-raw/paulists.R
+++ b/data-raw/paulists.R
@@ -39,4 +39,4 @@ paulist_missions <- read_csv("data-raw/paulist-missions.geocoded.csv") %>%
          volume,
          page)
 
-devtools::use_data(paulist_missions, overwrite = TRUE)
+usethis::use_data(paulist_missions, overwrite = TRUE)

--- a/data-raw/presbyterians.R
+++ b/data-raw/presbyterians.R
@@ -6,4 +6,4 @@ presbyterians <- pres %>%
   mutate(denomination = ifelse(denomination == "Reunited Presbyterians",
                                "Presbyterians", denomination))
 
-devtools::use_data(presbyterians, overwrite = TRUE)
+usethis::use_data(presbyterians, overwrite = TRUE)

--- a/data-raw/quasi-war.R
+++ b/data-raw/quasi-war.R
@@ -8,4 +8,4 @@ quasi_war <- quasi_war %>%
          month = month(date),
          day   = day(date))
 
-devtools::use_data(quasi_war, overwrite = TRUE)
+usethis::use_data(quasi_war, overwrite = TRUE)

--- a/data-raw/sarna.R
+++ b/data-raw/sarna.R
@@ -2,11 +2,11 @@ library(dplyr)
 library(tidyr)
 sarna <- read.csv("data-raw/sarna.csv", stringsAsFactors = FALSE)
 sarna <- sarna %>%
-  tbl_df() %>%
+  as_tibble() %>%
   select(year,
          population_low = estimate_low,
          population_high = estimate_high,
          percentage_low = percentage_pop_low,
          percentage_high = percentage_pop_high) %>%
   gather(estimate, value, -year)
-devtools::use_data(sarna, overwrite = TRUE)
+usethis::use_data(sarna, overwrite = TRUE)

--- a/data-raw/tudors.R
+++ b/data-raw/tudors.R
@@ -1,5 +1,5 @@
 library(dplyr)
-library(devtools)
+
 tudors <- read.csv("data-raw/tudors.csv", stringsAsFactors = FALSE) %>%
-  tbl_df
-use_data(tudors, overwrite = TRUE)
+  as_tibble
+usethis::use_data(tudors, overwrite = TRUE)

--- a/data-raw/us-national-population.R
+++ b/data-raw/us-national-population.R
@@ -5,7 +5,7 @@ us_national_population <- us_state_populations %>%
   select(year = YEAR,
          state = STATE,
          state_population = A00AA) %>%
-  tbl_df() %>%
+  as_tibble() %>%
   group_by(year) %>%
   summarize(population = sum(state_population, na.rm = TRUE))
-devtools::use_data(us_national_population, overwrite = TRUE)
+usethis::use_data(us_national_population, overwrite = TRUE)

--- a/data-raw/us-state-populations.R
+++ b/data-raw/us-state-populations.R
@@ -6,5 +6,5 @@ us_state_populations <- us_state_populations %>%
          year = YEAR,
          state = STATE,
          population = A00AA) %>%
-  tbl_df()
-devtools::use_data(us_state_populations, overwrite = TRUE)
+  as_tibble()
+usethis::use_data(us_state_populations, overwrite = TRUE)


### PR DESCRIPTION
This updates deprecated functions in `data-raw` scripts. These have not been rerun.
- `tbl_df` -> `as_tibble`
- `devtools::use_data` -> `usethis::use_data`
- `add_rownames` -> `rownames_to_column`