### PR TITLE
Fix `NA` in GitHub site

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-## Contributing
+# Contributing
 
 If you have a dataset that you think would be good for this package,
 feel free to contribute it. Datasets should include a source citation


### PR DESCRIPTION
Fixes an issue with the GitHub {pkgdown} site.
![image](https://github.com/user-attachments/assets/e04dd30e-7ce9-4baf-b406-0f0725ec0c67)
